### PR TITLE
feature: added no margin property to button to allow modifier combinations

### DIFF
--- a/src/ui/button/styles.js
+++ b/src/ui/button/styles.js
@@ -41,7 +41,7 @@ const StyledButton = styled.button`
 		width: 100%;
 	`}
 
-	${({ modifier }) => modifier === 'no-margin' && `
+	${({ modifier, noMargin }) => (modifier === 'no-margin' || noMargin) && `
 		margin-bottom: 0;
 	` || ''}
 


### PR DESCRIPTION
It is currently not possible to create a button that has both the ghost modifier and no-margin modifier. To solve this, I have added a seperate noMargin property to button to remove the bottom margin from a button. `modifier="no-margin"` will still work for backwards compatibility.