### PR TITLE
fix: use same proptypes as fontawesome to prevent warnings

### DIFF
--- a/src/ui/icon/icon.js
+++ b/src/ui/icon/icon.js
@@ -27,6 +27,7 @@ Icon.propTypes = {
 	className: PropTypes.string,
 	icon: PropTypes.oneOfType([
 		PropTypes.string,
+		PropTypes.array,
 		PropTypes.objectOf(PropTypes.any),
 	]).isRequired,
 	spin: PropTypes.bool,


### PR DESCRIPTION
I keep seeing "invalid proptypes" while providing an array is perfectly fine. [These are the "official" component's prop types.](https://github.com/FortAwesome/react-fontawesome/blob/master/src/components/FontAwesomeIcon.js#L112-L116)